### PR TITLE
Typography: add conditional to antialiased usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The [WAI-ARIA](https://www.w3.org/TR/wai-aria-1.1/) spec is deliberately not dup
 
 ## Typography
 
-- Fonts should have `-webkit-font-smoothing: antialiased` and `text-rendering: optimizeLegibility` applied for better legibility, except for dark themes [^1]
+- Fonts should have `-webkit-font-smoothing: antialiased` and `text-rendering: optimizeLegibility` applied for better legibility when using dark themes [^1]
 - Fonts should be subset based on the content, alphabet or relevant language(s)
 - Font weight should not change on hover or selected state to prevent layout shift
 - Font weights below 400 should not be used
@@ -89,7 +89,7 @@ The [WAI-ARIA](https://www.w3.org/TR/wai-aria-1.1/) spec is deliberately not dup
   - Highlight the relevant input(s) on form error(s)
 - Empty states should prompt to create a new item, with optional templates
 
-[^1]: When dark text is on a white background, antialiased texts will seem thinner because it has fewer pixels to play with, which might cause readability problems. More details on ["Please Stop 'Fixing' Font Smoothing"](https://usabilitypost.com/2012/11/05/stop-fixing-font-smoothing/)
+[^1]: When dark text is on a white background (a light theme), antialiased texts will seem thinner because it has fewer pixels to play with, which might cause readability problems. More details on ["Please Stop 'Fixing' Font Smoothing"](https://usabilitypost.com/2012/11/05/stop-fixing-font-smoothing/)
 [^2]: Switching between dark mode or light mode will trigger transitions on elements that are meant for explicit interactions like hover. We can [disable transitions temporarily](https://paco.me/writing/disable-theme-transitions) to prevent this. For Next.js, use [next-themes](https://github.com/pacocoursey/next-themes) which prevents transitions out of the box.
 [^3]: This is a matter of taste but some interactions just feel better with no motion. For example, the native macOS right click menu only animates out, not in, due to the frequent usage of it.
 [^4]: Most touch devices on press will temporarily flash the hover state, unless explicitly only defined for pointer devices with [`@media (hover: hover)`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/hover).

--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ The [WAI-ARIA](https://www.w3.org/TR/wai-aria-1.1/) spec is deliberately not dup
 
 ## Typography
 
-- Fonts should have `-webkit-font-smoothing: antialiased` applied for better legibility
-- Fonts should have `text-rendering: optimizeLegibility` applied for better legibility
+- Fonts should have `-webkit-font-smoothing: antialiased` and `text-rendering: optimizeLegibility` applied for better legibility, except for dark themes [^1]
 - Fonts should be subset based on the content, alphabet or relevant language(s)
 - Font weight should not change on hover or selected state to prevent layout shift
 - Font weights below 400 should not be used
@@ -33,12 +32,12 @@ The [WAI-ARIA](https://www.w3.org/TR/wai-aria-1.1/) spec is deliberately not dup
 
 ## Motion
 
-- Switching themes should not trigger transitions and animations on elements [^1]
+- Switching themes should not trigger transitions and animations on elements [^2]
 - Animation duration should not be more than 200ms for interactions to feel immediate
 - Animation values should be proportional to the trigger size:
   - Don't animate dialog scale in from 0 → 1, fade opacity and scale from ~0.8
   - Don't scale buttons on press from 1 → 0.8, but ~0.96, ~0.9, or so
-- Actions that are frequent and low in novelty should avoid extraneous animations: [^2]
+- Actions that are frequent and low in novelty should avoid extraneous animations: [^3]
   - Opening a right click menu
   - Deleting or adding items from a list
   - Hovering trivial buttons
@@ -47,7 +46,7 @@ The [WAI-ARIA](https://www.w3.org/TR/wai-aria-1.1/) spec is deliberately not dup
 
 ## Touch
 
-- Hover states should not be visible on touch press, use `@media (hover: hover)` [^3]
+- Hover states should not be visible on touch press, use `@media (hover: hover)` [^4]
 - Font size for inputs should not be smaller than 16px to prevent iOS zooming on focus
 - Inputs should not auto focus on touch devices as it will open the keyboard and cover the screen
 - Apply `muted` and `playsinline` to `<video />` tags to auto play on iOS
@@ -59,15 +58,15 @@ The [WAI-ARIA](https://www.w3.org/TR/wai-aria-1.1/) spec is deliberately not dup
 - Large `blur()` values for `filter` and `backdrop-filter` may be slow
 - Scaling and blurring filled rectangles will cause banding, use radial gradients instead
 - Sparingly enable GPU rendering with `transform: translateZ(0)` for unperformant animations
-- Toggle `will-change` on unperformant scroll animations for the duration of the animation [^4]
+- Toggle `will-change` on unperformant scroll animations for the duration of the animation [^5]
 - Auto-playing too many videos on iOS will choke the device, pause or even unmount off-screen videos
-- Bypass React's render lifecycle with refs for real-time values that can commit to the DOM directly [^5]
+- Bypass React's render lifecycle with refs for real-time values that can commit to the DOM directly [^6]
 - [Detect and adapt](https://github.com/GoogleChromeLabs/react-adaptive-hooks) to the hardware and network capabilities of the user's device
 
 ## Accessibility
 
-- Disabled buttons should not have tooltips, they are not accessible [^6]
-- Box shadow should be used for focus rings, not outline which won’t respect radius [^7]
+- Disabled buttons should not have tooltips, they are not accessible [^7]
+- Box shadow should be used for focus rings, not outline which won’t respect radius [^8]
 - Focusable elements in a sequential list should be navigable with <kbd>↑</kbd> <kbd>↓</kbd>
 - Focusable elements in a sequential list should be deletable with <kbd>⌘</kbd> <kbd>Backspace</kbd>
 - To open immediately on press, dropdown menus should trigger on `mousedown`, not `click`
@@ -90,10 +89,11 @@ The [WAI-ARIA](https://www.w3.org/TR/wai-aria-1.1/) spec is deliberately not dup
   - Highlight the relevant input(s) on form error(s)
 - Empty states should prompt to create a new item, with optional templates
 
-[^1]: Switching between dark mode or light mode will trigger transitions on elements that are meant for explicit interactions like hover. We can [disable transitions temporarily](https://paco.me/writing/disable-theme-transitions) to prevent this. For Next.js, use [next-themes](https://github.com/pacocoursey/next-themes) which prevents transitions out of the box.
-[^2]: This is a matter of taste but some interactions just feel better with no motion. For example, the native macOS right click menu only animates out, not in, due to the frequent usage of it.
-[^3]: Most touch devices on press will temporarily flash the hover state, unless explicitly only defined for pointer devices with [`@media (hover: hover)`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/hover).
-[^4]: Use [`will-change`](https://developer.mozilla.org/en-US/docs/Web/CSS/will-change) as a last resort to improve performance. Pre-emptively throwing it on elements for better performance may have the opposite effect.
-[^5]: This might be controversial but sometimes it can be beneficial to manipulate the DOM directly. For example, instead of relying on React re-rendering on every wheel event, we can track the delta in a ref and update relevant elements directly in the callback.
-[^6]: Disabled buttons do not appear in tab order in the DOM so the tooltip will never be announced for keyboard users and they won't know why the button is disabled.
-[^7]: As of 2023, Safari will not take the border radius of an element into account when defining custom outline styles. [Safari 16.4](https://developer.apple.com/documentation/safari-release-notes/safari-16_4-release-notes) has added support for `outline` following the curve of border radius. However, keep in mind that not everyone updates their OS immediately.
+[^1]: When dark text is on a white background, antialiased texts will seem thinner because it has fewer pixels to play with, which might cause readability problems. More details on ["Please Stop 'Fixing' Font Smoothing"](https://usabilitypost.com/2012/11/05/stop-fixing-font-smoothing/)
+[^2]: Switching between dark mode or light mode will trigger transitions on elements that are meant for explicit interactions like hover. We can [disable transitions temporarily](https://paco.me/writing/disable-theme-transitions) to prevent this. For Next.js, use [next-themes](https://github.com/pacocoursey/next-themes) which prevents transitions out of the box.
+[^3]: This is a matter of taste but some interactions just feel better with no motion. For example, the native macOS right click menu only animates out, not in, due to the frequent usage of it.
+[^4]: Most touch devices on press will temporarily flash the hover state, unless explicitly only defined for pointer devices with [`@media (hover: hover)`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/hover).
+[^5]: Use [`will-change`](https://developer.mozilla.org/en-US/docs/Web/CSS/will-change) as a last resort to improve performance. Pre-emptively throwing it on elements for better performance may have the opposite effect.
+[^6]: This might be controversial but sometimes it can be beneficial to manipulate the DOM directly. For example, instead of relying on React re-rendering on every wheel event, we can track the delta in a ref and update relevant elements directly in the callback.
+[^7]: Disabled buttons do not appear in tab order in the DOM so the tooltip will never be announced for keyboard users and they won't know why the button is disabled.
+[^8]: As of 2023, Safari will not take the border radius of an element into account when defining custom outline styles. [Safari 16.4](https://developer.apple.com/documentation/safari-release-notes/safari-16_4-release-notes) has added support for `outline` following the curve of border radius. However, keep in mind that not everyone updates their OS immediately.


### PR DESCRIPTION
I'd like to propose adding a conditional when using `-webkit-font-smoothing: antialiased` and `text-rendering: optimizeLegibility` for better typography legibility. 

Recently, I learned that this might cause the opposite result when applied to light themes, where a dark text is on a light background. Research more about this stop, I came across [this amazing article](https://usabilitypost.com/2012/11/05/stop-fixing-font-smoothing/) that argues that designers and front-end developers should stop using it as a _fix_ and deliberate its usage only when is necessary, meaning stop using it as a go-for solution and only add that when fonts were not designed to full all pixes properly. 

Here's an example with antialiased text in both contexts (light/dark themes). You can see that the second column on a light theme doesn't have great legibility like the non-antialiased version. While this is still subjective, I would not recommend it as a standard practice since it is not a default behavior on browsers.

![image](https://github.com/raunofreiberg/interfaces/assets/4838076/33368c16-dc97-4683-9f54-7b7b29b8cd4d)
