### PR TITLE
Exiting Modals with Loading UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The [WAI-ARIA](https://www.w3.org/TR/wai-aria-1.1/) spec is deliberately not dup
 - Illustrations built with HTML should have an explicit `aria-label` instead of announcing the raw DOM tree to people using screen readers
 - Gradient text should unset the gradient on `::selection` state
 - When using nested menus, use a "prediction cone" to prevent the pointer from accidentally closing the menu when moving across other elements.
+- When a modal or overlayed component pops up, if it has a loading state, ensure that users have a way of going back or closing it before loading completes.
 
 
 ## Design


### PR DESCRIPTION
Users should be able to exit loading state before loading is complete.